### PR TITLE
animate the dice rolls and disable button while rolling

### DIFF
--- a/src/Die.css
+++ b/src/Die.css
@@ -3,3 +3,39 @@
     padding: 0.25em;
     color: slateblue;
 }
+
+.Die-shaking {
+    animation-name: wobble;
+    animation-duration: 1s;
+}
+
+@keyframes wobble {
+    from {
+      transform: translate3d(0, 0, 0);
+    }
+  
+    15% {
+      transform: translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg);
+    }
+  
+    30% {
+      transform: translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg);
+    }
+  
+    45% {
+      transform: translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg);
+    }
+  
+    60% {
+      transform: translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg);
+    }
+  
+    75% {
+      transform: translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg);
+    }
+  
+    to {
+      transform: translate3d(0, 0, 0);
+    }
+  }
+  

--- a/src/Die.js
+++ b/src/Die.js
@@ -4,7 +4,10 @@ import './Die.css'
 class Die extends Component {
     render() {
         return (
-            <i className={`Die fas fa-dice-${this.props.face}`}></i>
+            <i className={`Die fas fa-dice-${this.props.face} ${
+                this.props.rolling && "Die-shaking"
+            }`}
+            />
         );
     }
 }

--- a/src/RollDice.js
+++ b/src/RollDice.js
@@ -8,7 +8,7 @@ class RollDice extends Component {
     };
     constructor(props) {
         super(props);
-        this.state = { die1: "one", die2: "one" };
+        this.state = { die1: "one", die2: "one", rolling: false };
         this.roll = this.roll.bind(this);
     }
     roll() {
@@ -20,16 +20,24 @@ class RollDice extends Component {
         Math.floor(Math.random() * this.props.sides.length)
     ];
     //set state with new rolls
-    this.setState({ die1: newDie1, die2: newDie2 });
-        }
+    this.setState({ die1: newDie1, die2: newDie2, rolling: true });
+
+    // Wait one second, then set rolling to false
+    setTimeout(() => {
+        this.setState({ rolling:false });
+        }, 1000);
+    }
+
     render() {
         return (
             <div className="RollDice">
                 <div className="RollDice-container">
-                    <Die face ={ this.state.die1 } />
-                    <Die face ={ this.state.die2 } />
+                    <Die face={ this.state.die1 } rolling={ this.state.rolling}/>
+                    <Die face={ this.state.die2 } rolling={this.state.rolling}/>
                 </div>
-                <button onClick= { this.roll }>Roll Dice!</button>
+                <button onClick={ this.roll} disabled={this.state.rolling}>
+                    { this.state.rolling ? "Rolling..." : "Roll Dice!" }
+                </button>
             </div>
         );
     }


### PR DESCRIPTION
This runs an animation of the dice rolls when the button is clicked, and disables the button during the roll/animation.  
To disable the button during a roll, in the **Rolldice.js** file, the initial value of `state` was adjusted.  An additional key/value pair was added to set `rolling` to `false`.  Then the `setState` for rolling was set to switch it to `true`.  A message then says either "Rolling..." or "Roll Dice".  A `setTimeout` is added to return the button to it's default after 1 second.  The button is then set where `onClick` would disable the button while dice are rolling.  

To animate the dice, a `keyframe` named `wobble` is added as a `Die-shaking` class to **Die.css**.  Then in **Die.js**, this class is selectively applied to a new prop named `this.props.rolling` using the logical `&&`.